### PR TITLE
ログアウトボタンが効かない修正

### DIFF
--- a/src/laravel/resources/js/Components/Dropdown.tsx
+++ b/src/laravel/resources/js/Components/Dropdown.tsx
@@ -48,8 +48,8 @@ const Trigger = ({ children }: Children) => {
     return (
         <>
             <div onClick={toggleOpen}>{children}</div>
-
-            {open && <div className="fixed inset-0 z-40" onClick={() => setOpen(false)}></div>}
+            {/* z-40の削除 理由:logoutが効かないため */}
+            {open && <div className="fixed inset-0" onClick={() => setOpen(false)}></div>}
         </>
     );
 };


### PR DESCRIPTION
ログアウトボタンより前面にdivが存在しておりその影響によりボタンが押せない状況だった。
z-40 = z-index1:40;と仮定してz-40を削除