### PR TITLE
managementのリストにdockerの欄を追加。

### DIFF
--- a/src/laravel/resources/js/Organisms/ManagementLists.tsx
+++ b/src/laravel/resources/js/Organisms/ManagementLists.tsx
@@ -5,6 +5,7 @@ import NavLink from '@/Atoms/NavLink';
 const ManagementTypes: Array<Array<string>> = [
     ['ユーザ一覧', 'user'],
     ['Git', 'git'],
+    // gitになっている部分をdockerに変える
     ['Docker', 'git'],
     // ['Docker', 'dashboard'],
     // ['Docker-Compose', 'dashboard'],


### PR DESCRIPTION
managementのリストにdockerの欄を追加しました。ルート部分に関してはgitのままでないと、リストが表示されないため現段階ではgitにしており、今後修正を行います。
ご確認のほど宜しくお願い致します。